### PR TITLE
Reads the UI names of devices and channels from the CCU

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,24 @@ The exporter can be run in different modes:
 
 ```bash
 
-usage: exporter.py [-h] --ccu_host CCU_HOST [--ccu_port CCU_PORT]
-                   [--interval INTERVAL] [--port PORT]
-                   [--config_file CONFIG_FILE] [--debug] [--dump_devices]
-                   [--dump_parameters DUMP_PARAMETERS]
+usage: exporter.py [-h] --ccu_host CCU_HOST [--ccu_port CCU_PORT] [--interval INTERVAL]
+                   [--namereload NAMERELOAD] [--port PORT] [--config_file CONFIG_FILE]
+                   [--debug] [--dump_devices] [--dump_parameters DUMP_PARAMETERS]
 
 optional arguments:
   -h, --help            show this help message and exit
   --ccu_host CCU_HOST   The hostname of the ccu instance
-  --ccu_port CCU_PORT   The port for the xmlrpc service
-  --interval INTERVAL   The interval between two gathering runs
+  --ccu_port CCU_PORT   The port for the xmlrpc service (2001 for BidcosRF, 2010 for HmIP)
+  --interval INTERVAL   The interval between two gathering runs in seconds
+  --namereload NAMERELOAD
+                        After how many intervals the device names are reloaded
   --port PORT           The port where to expose the exporter
   --config_file CONFIG_FILE
-                        A config file with e.g. supported types and device
-                        name mappings
+                        A config file with e.g. supported types and device name mappings
   --debug
   --dump_devices        Do not start exporter, just dump device list
   --dump_parameters DUMP_PARAMETERS
-                        Do not start exporter, just dump device parameters of
-                        given device
+                        Do not start exporter, just dump device parameters of given device
 ```
 
 Can be used via docker as well.
@@ -67,7 +66,8 @@ optional arguments:
 
 Metrics are all prefixed with `homematic_`, the remaining name is based on the parameter name within the device descriptor.
 All metrics are equipped with labels for the `ccu` instance, the device address, device type and parent device type.
-In addition a device mapping can be added with a `--mapping_file`. Device addresses can be mapped to custom names which are then usable as labels in e.g. Grafana.
+In addition a device mapping can be added via `--config_file`. Device addresses can be mapped to custom names which are then usable as labels in e.g. Grafana.
+If no mappings are in the config file, the names from the CCU user interface are used.
 
 ## Restrictions
 


### PR DESCRIPTION
Reads the UI names of devices and channels from the CCU if no custom mapping is given.
Names are reread every 30 gatherings (by default around every 30 minutes, configurable).