### PR TITLE
Added some devices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+CCU_HOST=ccu3.local
+CCU_USER=user
+CCU_PASS=password

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
+.env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+---
+version: "3"
+
+#networks:
+#  traefik:
+#    external: true
+
+services:
+  homematic-exporter:
+    build: .
+    #image: sfudeus/homematic_exporter
+    image: homematic_exporter
+    restart: unless-stopped
+#    networks:
+#      - traefik
+    ports:
+      - 8888:8010
+    command: --ccu_host "$CCU_HOST" --ccu_user "$CCU_USER" --ccu_pass "$CCU_PASS" --debug
+#    labels:
+#      - traefik.enable=true
+#      - traefik.port=8010

--- a/exporter.py
+++ b/exporter.py
@@ -68,6 +68,14 @@ class HomematicMetricsProcessor(threading.Thread):
         'HM-WDS30-OT2-SM',
         'HM-WDS40-TH-I',
         'HM-WDS40-TH-I-2',
+        'HmIP-BDT',                     # Homematic IP Dimmaktor für Markenschalter, Unterputzmontage
+        'HmIP-DBB',                     # Homematic IP Türklingeltaster
+        'HMIP-eTRV',                    # Homematic IP Heizkörperthermostat
+        'HmIP-eTRV-B1',                 # Homematic IP Heizkörperthermostat - basic
+        'HmIP-SRH',                     # Homematic IP Fenster-/ Drehgriffkontakt
+        'HMIP-WRC2',                    # Homematic IP Wandtaster 2-fach
+        'HmIP-WRC6',                    # Homematic IP Wandtaster 6-fach
+        'HMIP-WTH',                     # Homematic IP Wandthermostat
     ]
 
     # A list with channel numbers for devices where getParamset
@@ -220,15 +228,18 @@ class HomematicMetricsProcessor(threading.Thread):
                         paramDesc = paramsetDescription.get(key)
                         paramType = paramDesc.get('TYPE')
                         if paramType in ['FLOAT', 'INTEGER', 'BOOL']:
+                            logging.debug("Found {}: desc: {} key: {}".format(paramType, paramDesc, paramset.get(key)))
                             self.process_single_value(devAddress, devType, devParentAddress, devParentType, paramType, key, paramset.get(key))
                         elif paramType == 'ENUM':
                             logging.debug("Found {}: desc: {} key: {}".format(paramType, paramDesc, paramset.get(key)))
                             self.process_enum(devAddress, devType, devParentAddress, devParentType,
                                               paramType, key, paramset.get(key), paramDesc.get('VALUE_LIST'))
+                        elif paramType in ['ACTION', 'STRING']:
+                            logging.debug("Ignoring unsupported paramType {}, desc: {}, key: {}".format(paramType, paramDesc, paramset.get(key)))
                         else:
                             # ATM Unsupported like HEATING_CONTROL_HMIP.PARTY_TIME_START,
                             # HEATING_CONTROL_HMIP.PARTY_TIME_END, COMBINED_PARAMETER or ACTION
-                            logging.debug("Unknown paramType {}, desc: {}, key: {}".format(paramType, paramDesc, paramset.get(key)))
+                            logging.debug("Unknown unsupported paramType {}, desc: {}, key: {}".format(paramType, paramDesc, paramset.get(key)))
 
                     if paramset:
                         logging.debug("ParamsetDescription for {}".format(devAddress))


### PR DESCRIPTION
Added devices:
- HmIP-BDT
- HmIP-DBB
- HMIP-eTRV
- HmIP-eTRV-B1
-  HmIP-SRH
-  HMIP-WRC2
-  HmIP-WRC6
-  HMIP-WTH

Added docker-compose file with an .env.example
Improved debug messages

My ccu3 has the following unsopported things
```
# docker-compose logs homematic-exporter | grep "unsupported" | cut -d" " -f7- | sort | uniq
DEBUG - Ignoring unsupported paramType ACTION, desc: {'MIN': False, 'OPERATIONS': 4, 'MAX': True, 'FLAGS': 1, 'ID': 'PRESS_LONG', 'TYPE': 'ACTION', 'DEFAULT': False, 'CONTROL': 'BUTTON_NO_FUNCTION.LONG'}, key: None
DEBUG - Ignoring unsupported paramType ACTION, desc: {'MIN': False, 'OPERATIONS': 4, 'MAX': True, 'FLAGS': 1, 'ID': 'PRESS_SHORT', 'TYPE': 'ACTION', 'DEFAULT': False, 'CONTROL': 'BUTTON_NO_FUNCTION.SHORT'}, key: None
DEBUG - Ignoring unsupported paramType STRING, desc: {'MIN': '2000_01_01 00:00', 'OPERATIONS': 7, 'MAX': '2255_12_31 23:55', 'FLAGS': 1, 'ID': 'PARTY_TIME_END', 'TYPE': 'STRING', 'DEFAULT': '2000_01_01 00:00', 'CONTROL': 'HEATING_CONTROL_HMIP.PARTY_TIME_END'}, key: None
DEBUG - Ignoring unsupported paramType STRING, desc: {'MIN': '2000_01_01 00:00', 'OPERATIONS': 7, 'MAX': '2255_12_31 23:55', 'FLAGS': 1, 'ID': 'PARTY_TIME_START', 'TYPE': 'STRING', 'DEFAULT': '2000_01_01 00:00', 'CONTROL': 'HEATING_CONTROL_HMIP.PARTY_TIME_START'}, key: None
DEBUG - Ignoring unsupported paramType STRING, desc: {'MIN': '', 'OPERATIONS': 2, 'MAX': '', 'FLAGS': 1, 'ID': 'COMBINED_PARAMETER', 'TYPE': 'STRING', 'DEFAULT': ''}, key: None
INFO - Found unsupported top-level device XXXXXXXXXXXXXX of type HmIP-RCV-50
```