### PR TITLE
Add support for HmIP-STE2-PCB temperature sensors

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -27,6 +27,7 @@ class HomematicMetricsProcessor(threading.Thread):
         'HmIP-RCV-1',
         'HmIP-STH',
         'HmIP-STHD',
+        'HmIP-STE2-PCB',
         'HmIP-SWD',
         'HMIP-SWDO',
         'HmIP-SWSD',


### PR DESCRIPTION
HmIP-STE2-PCB  temperature sensors are a differential temperature sensor with 2 probes, that returns 3 values.

Value 1: Sensor 1
Value 2: Sensor 2
Value 3: Diff between sensor 1 and sensor 2

The return of the `homematic_exporter` seems plausible and very fine to me:

```
➜  ~ curl localhost:8010
python_gc_objects_collected_total{generation="0"} 285.0
python_gc_objects_collected_total{generation="1"} 173.0
python_gc_objects_collected_total{generation="2"} 0.0
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
python_gc_collections_total{generation="0"} 58.0
python_gc_collections_total{generation="1"} 5.0
python_gc_collections_total{generation="2"} 0.0
python_info{implementation="CPython",major="3",minor="10",patchlevel="8",version="3.10.8"} 1.0
homematic_devicecount{ccu="172.22.44.11"} 59.0
homematic_gathering_count_total{ccu="172.22.44.11"} 1.0
homematic_gathering_count_created{ccu="172.22.44.11"} 1.668284156632499e+09
homematic_generate_metrics_seconds_count{ccu="172.22.44.11"} 1.0
homematic_generate_metrics_seconds_sum{ccu="172.22.44.11"} 0.10192270099651068
homematic_generate_metrics_seconds_created{ccu="172.22.44.11"} 1.668284156632525e+09
homematic_read_names_seconds_count{ccu="172.22.44.11"} 1.0
homematic_read_names_seconds_sum{ccu="172.22.44.11"} 0.024493519973475486
homematic_read_names_seconds_created{ccu="172.22.44.11"} 1.6682841566078248e+09
homematic_config_pending{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_duty_cycle{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_low_bat{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_unreach{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_operating_voltage_status_set{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",homematic_operating_voltage_status_set="NORMAL",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 1.0
homematic_operating_voltage_status_set{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",homematic_operating_voltage_status_set="UNKNOWN",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_operating_voltage_status_set{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",homematic_operating_voltage_status_set="OVERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_operating_voltage_status_set{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",homematic_operating_voltage_status_set="EXTERNAL",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_rssi_device{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} -54.0
homematic_operating_voltage{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 3.2
homematic_update_pending{ccu="172.22.44.11",device="00281F29963EB6:0",device_type="MAINTENANCE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature{ccu="172.22.44.11",device="00281F29963EB6:1",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 47.3
homematic_actual_temperature{ccu="172.22.44.11",device="00281F29963EB6:2",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 31.5
homematic_actual_temperature{ccu="172.22.44.11",device="00281F29963EB6:3",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 15.8
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:1",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="NORMAL",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 1.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:1",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNKNOWN",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:1",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="OVERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:1",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNDERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:2",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="NORMAL",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 1.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:2",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNKNOWN",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:2",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="OVERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:2",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNDERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:3",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="NORMAL",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 1.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:3",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNKNOWN",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:3",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="OVERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
homematic_actual_temperature_status_set{ccu="172.22.44.11",device="00281F29963EB6:3",device_type="COND_SWITCH_TRANSMITTER_TEMPERATURE",homematic_actual_temperature_status_set="UNDERFLOW",mapped_name="HmIP-STE2-PCB 00281F29963EB6",parent_device_type="HmIP-STE2-PCB"} 0.0
```


Runtime looks fine to me as well:

```
(venv) ➜  homematic_exporter git:(master) python3 exporter.py --ccu_host 172.22.44.11 --ccu_port 2010
2022-11-12 21:24:17,784 - INFO - Starting thread for data gathering
2022-11-12 21:24:17,784 - INFO - Mapping 0 devices with custom names
2022-11-12 21:24:17,784 - INFO - Supporting 48 device types: HmIP-eTRV-2,HmIP-FSM,HMIP-PSM,HmIP-RCV-1,HmIP-STH,HmIP-STHD,HmIP-STE2-PCB,HmIP-SWD,HMIP-SWDO,HmIP-SWSD,HmIP-SWO-PL,HmIP-SWO-PR,HmIP-WTH-2,HM-CC-RT-DN,HM-Dis-EP-WM55,HM-Dis-WM55,HM-ES-PMSw1-Pl-DN-R5,HM-ES-TX-WM,HM-LC-Bl1-FM,HM-LC-Dim1PWM-CV,HM-LC-Dim1T-FM,HM-LC-RGBW-WM,HM-LC-Sw1-Pl-DN-R5,HM-LC-Sw1-FM,HM-LC-Sw2-FM,HM-OU-CFM-Pl,HM-OU-CFM-TW,HM-PBI-4-FM,HM-PB-2-WM55,HM-PB-6-WM55,HM-RC-P1,HM-RC-4-2,HM-RC-8,HM-Sec-MDIR-2,HM-Sec-SCo,HM-Sec-SC-2,HM-Sec-SD-2,HM-Sec-TiS,HM-Sen-LI-O,HM-Sen-MDIR-O,HM-Sen-MDIR-WM55,HM-SwI-3-FM,HM-TC-IT-WM-W-EU,HM-WDS10-TH-O,HM-WDS100-C6-O-2,HM-WDS30-OT2-SM,HM-WDS40-TH-I,HM-WDS40-TH-I-2
2022-11-12 21:24:17,784 - INFO - Exposing metrics on port 8010
2022-11-12 21:24:17,809 - INFO - Read 375 device names from CCU
2022-11-12 21:24:17,809 - INFO - Gathering metrics
2022-11-12 21:24:17,838 - INFO - Found top-level device 00281F29963EB6 of type HmIP-STE2-PCB with 4 children
2022-11-12 21:24:17,915 - INFO - Found unsupported top-level device 001F5A4993DA3A of type RPI-RF-MOD
2022-11-12 21:24:17,915 - INFO - Found unsupported top-level device HmIP-RCV-1 of type HmIP-RCV-50
```