### PR TITLE
Add a diagnostic `refresh_age` metric and corresponding container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ COPY requirements.txt /tmp
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 COPY exporter.py /usr/local/bin/homematic_exporter
+COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 
 ENTRYPOINT [ "/usr/local/bin/homematic_exporter" ]
 
 EXPOSE 8010
+HEALTHCHECK --interval=20s --timeout=3s \
+    CMD bash /usr/local/bin/healthcheck.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim-bookworm
 COPY requirements.txt /tmp
+RUN apt-get update && apt-get install curl -y
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 COPY exporter.py /usr/local/bin/homematic_exporter

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -4,7 +4,7 @@
 maxage=${1:-60}
 
 # Get the age of the last successful metrics refresh in seconds
-age=$(curl -s http://localhost:9040/metrics | grep 'homematic_refresh_age{' | cut -d ' ' -f2 | cut -d '.' -f1)
+age=$(curl -s http://localhost:9040/metrics | grep 'homematic_refresh_age_seconds{' | cut -d ' ' -f2 | cut -d '.' -f1)
 
 if [[ $age -lt $maxage ]]; then
     exit 0

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# First argument is the maximum age in seconds (default: 60)
+maxage=${1:-60}
+
+# Get the age of the last successful metrics refresh in seconds
+age=$(curl -s http://localhost:9040/metrics | grep 'homematic_refresh_age{' | cut -d ' ' -f2 | cut -d '.' -f1)
+
+if [[ $age -lt $maxage ]]; then
+    exit 0
+else
+    # Maximum age exceeded → unhealthy
+    exit 1
+fi


### PR DESCRIPTION
Hi @sfudeus, thanks for this great exporter!

Every now and then my container appears to hang, producing such gaps until I restart it:

![image](https://github.com/sfudeus/homematic_exporter/assets/5894642/ee060caa-1e4b-4579-b06e-f50be77f63d4)

I assume that some internal loop crashes, but the logs don't indicate anything.

To notice when things to out of order, I introduced a new metric:

```
# HELP homematic_refresh_age Seconds since the last successful refresh.
# TYPE homematic_refresh_age gauge
homematic_refresh_age{ccu="192.168.178.30"} 4.156044244766235
```

In combination with a healthcheck script and [docker-autoheal](https://github.com/willfarrell/docker-autoheal) this makes it easy to automatically restart the container.

![image](https://github.com/sfudeus/homematic_exporter/assets/5894642/630de5e7-1faf-4161-a1ee-525038c53274)